### PR TITLE
Exclude private API calls from swagger

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,21 +2,76 @@
 
 
 [[projects]]
+  digest = "1:d1665c44bd5db19aaee18d1b6233c99b0b9a986e8bccb24ef54747547a48027f"
+  name = "github.com/PuerkitoBio/purell"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c739832d67eb1e9cc478a19cc1a1ccd78df0397bf8a32978b759152e205f644b"
+  name = "github.com/PuerkitoBio/urlesc"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "de5bf2ad457846296e2031421a34e2568e304e35"
+
+[[projects]]
+  digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
 
 [[projects]]
+  digest = "1:953a2628e4c5c72856b53f5470ed5e071c55eccf943d798d42908102af2a610f"
+  name = "github.com/go-openapi/jsonpointer"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ef5f0afec364d3b9396b7b77b43dbe26bf1f8004"
+  version = "v0.17.1"
+
+[[projects]]
+  digest = "1:81210e0af657a0fb3638932ec68e645236bceefa4c839823db0c4d918f080895"
+  name = "github.com/go-openapi/jsonreference"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8483a886a90412cd6858df4ea3483dce9c8e35a3"
+  version = "v0.17.1"
+
+[[projects]]
+  digest = "1:394fed5c0425fe01da3a34078adaa1682e4deaea6e5d232dde25c4034004c151"
+  name = "github.com/go-openapi/spec"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5bae59e25b21498baea7f9d46e9c147ec106a42e"
+  version = "v0.17.1"
+
+[[projects]]
+  digest = "1:32f3d2e7f343de7263c550d696fb8a64d3c49d8df16b1ddfc8e80e1e4b3233ce"
+  name = "github.com/go-openapi/swag"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5899d5c5e619fda5fa86e14795a835f473ca284c"
+  version = "v0.17.1"
+
+[[projects]]
+  digest = "1:5cae6c173646d9230aecf8074c171edb4fb9a37f074c5c89ba2fece20b6703b6"
   name = "github.com/go-resty/resty"
   packages = ["."]
+  pruneopts = "UT"
   revision = "f8815663de1e64d57cdd4ee9e2b2fa96977a030e"
 
 [[projects]]
+  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = "UT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  digest = "1:b0776c2af0c01ba7e1290bdbc9c01f86d89427efa12fe19cc6528397a44756c6"
   name = "github.com/golang/protobuf"
   packages = [
     "jsonpb",
@@ -33,16 +88,32 @@
     "ptypes/empty",
     "ptypes/struct",
     "ptypes/timestamp",
-    "ptypes/wrappers"
+    "ptypes/wrappers",
   ]
+  pruneopts = "UT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
 
 [[projects]]
+  branch = "master"
+  digest = "1:84a5a2b67486d5d67060ac393aa255d05d24ed5ee41daecd5635ec22657b6492"
+  name = "github.com/mailru/easyjson"
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter",
+  ]
+  pruneopts = "UT"
+  revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
+
+[[projects]]
+  digest = "1:d673e95129a1107bfd04e093751a5e1267faabc27d218d824fb013f57ac08f55"
   name = "github.com/rogpeppe/fastuuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "6724a57986aff9bff1a1770e9347036def7c89f6"
 
 [[projects]]
+  digest = "1:1e482b1582e7b97950f868d6a9d164571f081808a9b3dd353bb03ea120c4c1c0"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -53,11 +124,13 @@
     "internal/timeseries",
     "lex/httplex",
     "publicsuffix",
-    "trace"
+    "trace",
   ]
+  pruneopts = "UT"
   revision = "640f4622ab692b87c2f3a94265e6f579fe38263d"
 
 [[projects]]
+  digest = "1:0c56024909189aee3364b7f21a95a27459f718aa7c199a5c111c36cfffd9eaef"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -73,21 +146,26 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
+    "width",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
 
 [[projects]]
+  digest = "1:546ffd1442dd61b49cde9765da5486fbc6c68825efc8fccec0afa944a56b68d0"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
     "googleapis/rpc/errdetails",
     "googleapis/rpc/status",
-    "protobuf/field_mask"
+    "protobuf/field_mask",
   ]
+  pruneopts = "UT"
   revision = "86e600f69ee4704c6efbf6a2a40a5c10700e76c2"
 
 [[projects]]
+  digest = "1:f47fb9bd1a9173285be23a1a1342e019abddfd787216e7f2c555ddba837e98ce"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -112,18 +190,51 @@
     "stats",
     "status",
     "tap",
-    "transport"
+    "transport",
   ]
+  pruneopts = "UT"
   revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
 
 [[projects]]
+  digest = "1:6570992c02a2137a20be83990a979b6fe892e20ecdc6b756449989b2a7efb8ae"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e3a3d005ebf93db02b6c7ddc886adc39342b492105fc1b6c4d0c362a43e6adf6"
+  input-imports = [
+    "github.com/ghodss/yaml",
+    "github.com/go-openapi/spec",
+    "github.com/go-resty/resty",
+    "github.com/golang/glog",
+    "github.com/golang/protobuf/jsonpb",
+    "github.com/golang/protobuf/proto",
+    "github.com/golang/protobuf/protoc-gen-go",
+    "github.com/golang/protobuf/protoc-gen-go/descriptor",
+    "github.com/golang/protobuf/protoc-gen-go/generator",
+    "github.com/golang/protobuf/protoc-gen-go/plugin",
+    "github.com/golang/protobuf/ptypes",
+    "github.com/golang/protobuf/ptypes/any",
+    "github.com/golang/protobuf/ptypes/duration",
+    "github.com/golang/protobuf/ptypes/empty",
+    "github.com/golang/protobuf/ptypes/struct",
+    "github.com/golang/protobuf/ptypes/timestamp",
+    "github.com/golang/protobuf/ptypes/wrappers",
+    "github.com/rogpeppe/fastuuid",
+    "golang.org/x/net/context",
+    "google.golang.org/genproto/googleapis/api/annotations",
+    "google.golang.org/genproto/googleapis/rpc/errdetails",
+    "google.golang.org/genproto/googleapis/rpc/status",
+    "google.golang.org/genproto/protobuf/field_mask",
+    "google.golang.org/grpc",
+    "google.golang.org/grpc/codes",
+    "google.golang.org/grpc/connectivity",
+    "google.golang.org/grpc/grpclog",
+    "google.golang.org/grpc/metadata",
+    "google.golang.org/grpc/status",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -47,6 +47,9 @@ type Registry struct {
 	// atlasPatch ...
 	atlasPatch bool
 
+	//withPrivateOperations if true exclude all operations with tag "private"
+	withPrivateOperations bool
+
 	// mergeFileName target swagger file name after merge
 	mergeFileName string
 }
@@ -323,6 +326,15 @@ func (r *Registry) IsAtlasPatch() bool {
 
 func (r *Registry) SetAtlasPatch(atlas bool) {
 	r.atlasPatch = atlas
+}
+
+// IsWithPrivateOperations if true exclude all operations with tag "private"
+func (r *Registry) IsWithPrivateOperations() bool {
+	return r.withPrivateOperations
+}
+
+func (r *Registry) SetWithPrivateOperations(withPrivateOperations bool) {
+	r.withPrivateOperations = withPrivateOperations
 }
 
 // SetMergeFileName controls the target swagger file name out of multiple protos

--- a/protoc-gen-swagger/README.md
+++ b/protoc-gen-swagger/README.md
@@ -27,4 +27,24 @@ Patch includes following changes:
      query parameters, also id.payload_id is replaced with id in path.
 
    * Unused references elimination.
-
+   
+   * Exclude all operations tagged as "private" see example below
+       ```
+       rpc Update (UpdateNetworkRequest) returns (UpdateNetworkResponse) {
+           option (google.api.http) = {
+             put: "/network/{payload.id.resource_id}"
+             body: "payload"
+       
+             additional_bindings {
+               patch: "/network/{payload.id.resource_id}",
+               body:  "payload"
+             }
+       
+           };
+           option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
+             tags: "private"
+           };
+         }
+       ```
+   * Introduced new `with_private` flag if set generate service.private.swagger.json
+   with all operation (including tagged as "private")

--- a/protoc-gen-swagger/genswagger/generator.go
+++ b/protoc-gen-swagger/genswagger/generator.go
@@ -121,41 +121,28 @@ func (g *generator) Generate(targets []*descriptor.File) ([]*plugin.CodeGenerato
 	if g.reg.IsAllowMerge() {
 		targetSwagger := mergeTargetFile(swaggers, g.reg.GetMergeFileName())
 		resFile := encodeSwagger(targetSwagger)
-		fileContent := []byte(*resFile.Content)
 		if g.reg.IsAtlasPatch() {
-			resFile.Content = proto.String(atlasSwagger(fileContent, false))
+			resFile.Content = proto.String(atlasSwagger([]byte(*resFile.Content), g.reg.IsWithPrivateOperations()))
+			if g.reg.IsWithPrivateOperations(){
+				privateFileName := strings.Replace(resFile.GetName(), ".swagger.json", ".private.swagger.json", -1)
+				resFile.Name = &privateFileName
+			}
 		}
 		files = append(files, resFile)
 		glog.V(1).Infof("New swagger file will emit")
-
-		if g.reg.IsAtlasPatch() {
-			privateFileName := strings.Replace(resFile.GetName(), ".swagger.json", ".private.swagger.json", -1)
-			resFilePrivate := &plugin.CodeGeneratorResponse_File{
-				Name: &privateFileName,
-				Content: proto.String(atlasSwagger(fileContent, true)),
-			}
-			files = append(files, resFilePrivate)
-			glog.V(1).Infof("New private swagger file will emit")
-		}
 	} else {
 		for _, file := range swaggers {
 			resFile := encodeSwagger(file)
 			fileContent := []byte(*resFile.Content)
 			if g.reg.IsAtlasPatch() {
-				resFile.Content = proto.String(atlasSwagger(fileContent, false))
+				resFile.Content = proto.String(atlasSwagger(fileContent, g.reg.IsWithPrivateOperations()))
+				if g.reg.IsWithPrivateOperations(){
+					privateFileName := strings.Replace(resFile.GetName(), ".swagger.json", ".private.swagger.json", -1)
+					resFile.Name = &privateFileName
+				}
 			}
 			files = append(files, resFile)
 			glog.V(1).Infof("New swagger file will emit")
-
-			if g.reg.IsAtlasPatch() {
-				privateFileName := strings.Replace(resFile.GetName(), ".swagger.json", ".private.swagger.json", -1)
-				resFilePrivate := &plugin.CodeGeneratorResponse_File{
-					Name: &privateFileName,
-					Content : proto.String(atlasSwagger(fileContent, true)),
-				}
-				files = append(files, resFilePrivate)
-				glog.V(1).Infof("New private swagger file will emit")
-			}
 		}
 	}
 	return files, nil

--- a/protoc-gen-swagger/genswagger/generator.go
+++ b/protoc-gen-swagger/genswagger/generator.go
@@ -121,19 +121,41 @@ func (g *generator) Generate(targets []*descriptor.File) ([]*plugin.CodeGenerato
 	if g.reg.IsAllowMerge() {
 		targetSwagger := mergeTargetFile(swaggers, g.reg.GetMergeFileName())
 		resFile := encodeSwagger(targetSwagger)
+		fileContent := []byte(*resFile.Content)
 		if g.reg.IsAtlasPatch() {
-			resFile.Content = proto.String(atlasSwagger([]byte(*resFile.Content)))
+			resFile.Content = proto.String(atlasSwagger(fileContent, false))
 		}
 		files = append(files, resFile)
 		glog.V(1).Infof("New swagger file will emit")
+
+		if g.reg.IsAtlasPatch() {
+			privateFileName := strings.Replace(resFile.GetName(), ".swagger.json", ".private.swagger.json", -1)
+			resFilePrivate := &plugin.CodeGeneratorResponse_File{
+				Name: &privateFileName,
+				Content: proto.String(atlasSwagger(fileContent, true)),
+			}
+			files = append(files, resFilePrivate)
+			glog.V(1).Infof("New private swagger file will emit")
+		}
 	} else {
 		for _, file := range swaggers {
 			resFile := encodeSwagger(file)
+			fileContent := []byte(*resFile.Content)
 			if g.reg.IsAtlasPatch() {
-				resFile.Content = proto.String(atlasSwagger([]byte(*resFile.Content)))
+				resFile.Content = proto.String(atlasSwagger(fileContent, false))
 			}
 			files = append(files, resFile)
 			glog.V(1).Infof("New swagger file will emit")
+
+			if g.reg.IsAtlasPatch() {
+				privateFileName := strings.Replace(resFile.GetName(), ".swagger.json", ".private.swagger.json", -1)
+				resFilePrivate := &plugin.CodeGeneratorResponse_File{
+					Name: &privateFileName,
+					Content : proto.String(atlasSwagger(fileContent, true)),
+				}
+				files = append(files, resFilePrivate)
+				glog.V(1).Infof("New private swagger file will emit")
+			}
 		}
 	}
 	return files, nil

--- a/protoc-gen-swagger/main.go
+++ b/protoc-gen-swagger/main.go
@@ -22,6 +22,7 @@ var (
 	allowMerge           = flag.Bool("allow_merge", false, "if set, generation one swagger file out of multiple protos")
 	mergeFileName        = flag.String("merge_file_name", "apidocs", "target swagger file name prefix after merge")
 	atlasPatch           = flag.Bool("atlas_patch", false, "if set, generation will be proceded with atlas-patch changes")
+	withPrivate          = flag.Bool("with_private", false, "if unset, generate swagger schema without operations 0 as 'private' work only if atlas_patch set")
 )
 
 func main() {
@@ -57,6 +58,7 @@ func main() {
 	reg.SetAllowDeleteBody(*allowDeleteBody)
 	reg.SetAllowMerge(*allowMerge)
 	reg.SetAtlasPatch(*atlasPatch)
+	reg.SetWithPrivateOperations(*withPrivate)
 	reg.SetMergeFileName(*mergeFileName)
 	for k, v := range pkgMap {
 		reg.AddPkgMap(k, v)


### PR DESCRIPTION
If we use atlas_patch and  tagged  our rpc method as "private" see example  below
```
rpc Update (UpdateNetworkRequest) returns (UpdateNetworkResponse) {
    option (google.api.http) = {
      put: "/network/{payload.id.resource_id}"
      body: "payload"

      additional_bindings {
        patch: "/network/{payload.id.resource_id}",
        body:  "payload"
      }

    };
    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_operation) = {
      tags: "private"
    };
  }
```
this method will be excluded from service.swagger.json, but if we specified with_private=true flag, plugin will generate service.private.swagger.json with all possible operation for path