### PR TITLE
fix type casting

### DIFF
--- a/protoc-gen-swagger/genswagger/atlas_patch.go
+++ b/protoc-gen-swagger/genswagger/atlas_patch.go
@@ -483,8 +483,7 @@ func filterDefinitions() (newDefinitions spec.Definitions) {
 	if err := json.Unmarshal(marh, &v); err != nil {
 		panic(err.Error())
 	}
-
-	defs := v["definitions"].(map[string]interface{})
+	defs, _ := v["definitions"].(map[string]interface{})
 	newDefinitions = make(spec.Definitions)
 
 	for rk := range gatherRefs(v["paths"]) {


### PR DESCRIPTION
In some cases we have empty definitions and protoc-gen-swagger will panic if definition empty fix it 