### PR TITLE
Add patch for id of type google.protobuf.StringValue

### DIFF
--- a/protoc-gen-swagger/genswagger/atlas_patch.go
+++ b/protoc-gen-swagger/genswagger/atlas_patch.go
@@ -91,7 +91,7 @@ func atlasSwagger(b []byte, withPrivateMethods, withCustomAnnotations bool) stri
 	for pn, pi := range sw.Paths.Paths {
 		var pnElements []string
 		for _, v := range strings.Split(pn, "/") {
-			if strings.HasSuffix(v, "id.resource_id}") || strings.HasSuffix(v, ".id}") {
+			if strings.HasSuffix(v, "id.resource_id}") || strings.HasSuffix(v, ".id}") || strings.HasSuffix(v, "id.value}") {
 				pnElements = append(pnElements, "{id}")
 			} else {
 				pnElements = append(pnElements, v)
@@ -180,7 +180,7 @@ The service-defined string used to identify a page of resources. A null value in
 					default:
 					}
 					// Replace resource_id with id
-				} else if strings.HasSuffix(param.Name, "id.resource_id") || strings.HasSuffix(param.Name, ".id") {
+				} else if strings.HasSuffix(param.Name, "id.resource_id") || strings.HasSuffix(param.Name, ".id") || strings.HasSuffix(param.Name, "id.value") {
 					param.Name = "id"
 					fixedParams = append(fixedParams, param)
 				} else if strings.HasPrefix(param.Description, "tagging.api.") {
@@ -192,6 +192,9 @@ The service-defined string used to identify a page of resources. A null value in
 					default:
 						fixedParams = append(fixedParams, param)
 					}
+				} else if strings.HasSuffix(param.Name, "id") && param.In == "query" {
+					//skip ID if its present in 'query'
+					continue
 				} else {
 					// Gather ref in body.
 					if param.In == "body" && param.Schema != nil {

--- a/protoc-gen-swagger/genswagger/atlas_patch_test.go
+++ b/protoc-gen-swagger/genswagger/atlas_patch_test.go
@@ -70,6 +70,38 @@ func TestAtlasPatch(t *testing.T) {
           "Service"
         ]
       }
+    },
+    "/api/discovery/v1/mergeconfigs/{id.value}": {
+      "get": {
+        "tags": [
+          "Service"
+        ],
+        "operationId": "Read",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "The string value.",
+            "name": "id.value",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GET operation response",
+            "schema": {
+              "$ref": "#/definitions/exampleRead"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -93,7 +125,13 @@ func TestAtlasPatch(t *testing.T) {
 				if param.Name == "application_name" || param.Name == "resource_type" {
 					t.Error("atlasPatch should filter out required params that are not part of URL")
 				}
-				if param.Name == "resource_id" {
+				if param.Name == "id.value" {
+					t.Error("atlasPatch should replace id.value in URL with just id")
+				}
+				if param.Name == "id" && param.In == "query" {
+					t.Error("atlasPatch should filter out id present in query")
+				}
+				if param.Name == "resource_id" || (param.Name == "id" && param.In == "path"){
 					resourceIDPresent = true
 				}
 			}


### PR DESCRIPTION
When we use [infobloxopen/atlas-gentool:v21.9](https://github.com/infobloxopen/atlas-gentool/tree/v21.9) for generating *.pb.go and swagger files

In proto file if we have defined **`Id as google.protobuf.StringValue`** type and it is used in the URL/path as `id.value`, 
the generated swagger files have Id field distributed among path and query parameters, also id.value is not replaced with id in path like we see for Id of type atlas.rpc.identifier. 

This PR is to provide similar support for Id of type google.protobuf.StringValue as we do for Id  of type atlas.rpc.identifier.

Expected behaviour - Id of type google.protobuf.StringValue in path is treated correctly and not distributed among path and query parameters, also id.value is replaced with id in path.