### PR TITLE
Update check to skip 'id' param if present in query 

### DIFF
--- a/protoc-gen-swagger/genswagger/atlas_patch.go
+++ b/protoc-gen-swagger/genswagger/atlas_patch.go
@@ -192,7 +192,7 @@ The service-defined string used to identify a page of resources. A null value in
 					default:
 						fixedParams = append(fixedParams, param)
 					}
-				} else if strings.HasSuffix(param.Name, "id") && param.In == "query" {
+				} else if param.Name == "id" && param.In == "query" {
 					//skip ID if its present in 'query'
 					continue
 				} else {

--- a/protoc-gen-swagger/genswagger/atlas_patch_test.go
+++ b/protoc-gen-swagger/genswagger/atlas_patch_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 )
 
-
 func TestAtlasPatch(t *testing.T) {
 	input := `
 {
@@ -71,7 +70,7 @@ func TestAtlasPatch(t *testing.T) {
         ]
       }
     },
-    "/api/discovery/v1/mergeconfigs/{id.value}": {
+    "/api/v1/example/{id.value}": {
       "get": {
         "tags": [
           "Service"
@@ -131,7 +130,7 @@ func TestAtlasPatch(t *testing.T) {
 				if param.Name == "id" && param.In == "query" {
 					t.Error("atlasPatch should filter out id present in query")
 				}
-				if param.Name == "resource_id" || (param.Name == "id" && param.In == "path"){
+				if param.Name == "resource_id" || (param.Name == "id" && param.In == "path") {
 					resourceIDPresent = true
 				}
 			}


### PR DESCRIPTION
- Correcting the check as pointed out by @rvinfoblox https://github.com/infobloxopen/grpc-gateway/commit/ad666c53cb4982b96efaae9051ca7bc5ac8dfe76#r118443132  to skip only param with name **id** if its present in query instead of skipping all param with suffix id
